### PR TITLE
Add support for closing the fab speed dial by tapping on the background

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.0.0-alpha9'
+        classpath 'com.android.tools.build:gradle:2.0.0-beta2'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,8 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.0.0-beta5'
+        classpath 'com.android.tools.build:gradle:2.0.0-beta6'
+
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/library/src/main/java/io/github/yavski/fabspeeddial/FabSpeedDial.java
+++ b/library/src/main/java/io/github/yavski/fabspeeddial/FabSpeedDial.java
@@ -49,6 +49,7 @@ import android.view.ViewGroup;
 import android.view.ViewParent;
 import android.widget.FrameLayout;
 import android.widget.LinearLayout;
+import android.widget.RelativeLayout;
 import android.widget.TextView;
 
 import java.util.HashMap;
@@ -206,7 +207,7 @@ public class FabSpeedDial extends LinearLayout implements View.OnClickListener {
         }
 
         miniFabTitleBackgroundTint = typedArray.getColorStateList(R.styleable.FabSpeedDial_miniFabTitleBackgroundTint);
-        if(miniFabTitleBackgroundTint == null){
+        if (miniFabTitleBackgroundTint == null) {
             miniFabTitleBackgroundTint = getColorStateList(R.color.mini_fab_title_background_tint);
         }
 
@@ -214,7 +215,7 @@ public class FabSpeedDial extends LinearLayout implements View.OnClickListener {
 
 
         miniFabTitleTextColor = typedArray.getColor(R.styleable.FabSpeedDial_miniFabTitleTextColor,
-            ContextCompat.getColor(getContext(), R.color.title_text_color));
+                ContextCompat.getColor(getContext(), R.color.title_text_color));
 
         useTouchGuard = typedArray.getBoolean(R.styleable.FabSpeedDial_touchGuard, false);
     }
@@ -277,14 +278,19 @@ public class FabSpeedDial extends LinearLayout implements View.OnClickListener {
         if (useTouchGuard) {
             ViewParent parent = getParent();
 
+            touchGuard = new View(getContext());
+            touchGuard.setOnClickListener(this);
+            touchGuard.setWillNotDraw(true);
+            touchGuard.setVisibility(GONE);
             if (parent instanceof FrameLayout) {
-                touchGuard = new View(getContext());
                 ((FrameLayout) parent).addView(touchGuard, ((FrameLayout) parent).indexOfChild(this));
-                touchGuard.setOnClickListener(this);
-                touchGuard.setWillNotDraw(true);
-                touchGuard.setVisibility(GONE);
+            } else if (parent instanceof RelativeLayout) {
+                ((RelativeLayout) parent).addView(
+                        touchGuard, ((RelativeLayout) parent).indexOfChild(this),
+                        new RelativeLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT,
+                                ViewGroup.LayoutParams.MATCH_PARENT));
             } else {
-                Log.d(TAG, "touchGuard requires that the parent of this FabSpeedDialer be a FrameLayout");
+                Log.d(TAG, "touchGuard requires that the parent of this FabSpeedDialer be a FrameLayout or RelativeLayout");
             }
         }
 

--- a/library/src/main/java/io/github/yavski/fabspeeddial/FabSpeedDial.java
+++ b/library/src/main/java/io/github/yavski/fabspeeddial/FabSpeedDial.java
@@ -84,6 +84,7 @@ public class FabSpeedDial extends LinearLayout implements View.OnClickListener {
          */
         boolean onMenuItemSelected(MenuItem menuItem);
 
+        void onMenuClosed();
     }
 
     private static final String TAG = FabSpeedDial.class.getSimpleName();
@@ -277,6 +278,8 @@ public class FabSpeedDial extends LinearLayout implements View.OnClickListener {
                 }
             });
         }
+
+        setOnClickListener(this);
     }
 
     private void newNavigationMenu() {
@@ -301,7 +304,9 @@ public class FabSpeedDial extends LinearLayout implements View.OnClickListener {
         removeFabMenuItems();
 
         if (menuListener != null) {
-            if (v instanceof FloatingActionButton) {
+            if (v == this) {
+                menuListener.onMenuClosed();
+            } else if (v instanceof FloatingActionButton) {
                 menuListener.onMenuItemSelected(fabMenuItemMap.get(v));
             } else if (v instanceof CardView) {
                 menuListener.onMenuItemSelected(cardViewMenuItemMap.get(v));
@@ -319,7 +324,9 @@ public class FabSpeedDial extends LinearLayout implements View.OnClickListener {
         ViewCompat.setAlpha(menuItemsLayout, 1f);
         for (int i = 0; i < navigationMenu.size(); i++) {
             MenuItem menuItem = navigationMenu.getItem(i);
-            menuItemsLayout.addView(createFabMenuItem(menuItem));
+            if (menuItem.isVisible()) {
+                menuItemsLayout.addView(createFabMenuItem(menuItem));
+            }
         }
         animateFabMenuItemsIn();
     }

--- a/library/src/main/java/io/github/yavski/fabspeeddial/SimpleMenuListenerAdapter.java
+++ b/library/src/main/java/io/github/yavski/fabspeeddial/SimpleMenuListenerAdapter.java
@@ -20,4 +20,8 @@ public class SimpleMenuListenerAdapter implements FabSpeedDial.MenuListener {
     public boolean onMenuItemSelected(MenuItem menuItem) {
         return false;
     }
+
+    @Override
+    public void onMenuClosed() {
+    }
 }

--- a/library/src/main/res/layout/fab_speed_dial_bottom.xml
+++ b/library/src/main/res/layout/fab_speed_dial_bottom.xml
@@ -18,6 +18,10 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
+    <View android:layout_width="1dp"
+        android:layout_height="0dp"
+        android:layout_weight="1" />
+
     <LinearLayout
         android:id="@+id/menu_items_layout"
         android:layout_width="wrap_content"

--- a/library/src/main/res/layout/fab_speed_dial_bottom.xml
+++ b/library/src/main/res/layout/fab_speed_dial_bottom.xml
@@ -18,10 +18,6 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <View android:layout_width="1dp"
-        android:layout_height="0dp"
-        android:layout_weight="1" />
-
     <LinearLayout
         android:id="@+id/menu_items_layout"
         android:layout_width="wrap_content"

--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -34,6 +34,7 @@
         <attr name="miniFabBackgroundTint" format="color|reference" />
         <attr name="miniFabDrawableTint" format="color|reference" />
         <attr name="miniFabTitleTextColor" format="color|reference" />
+        <attr name="touchGuard" format="boolean" />
 
     </declare-styleable>
 


### PR DESCRIPTION
This requires setting up the FabSpeedDial as a full-screen component, and since the gravity is a bit strange, I had to add a spacer to make sure the FAB stays at the bottom.
