### PR TITLE
Tint Mini Fab Title Cards and Option to hide title cards

### DIFF
--- a/library/src/main/java/io/github/yavski/fabspeeddial/FabSpeedDial.java
+++ b/library/src/main/java/io/github/yavski/fabspeeddial/FabSpeedDial.java
@@ -114,6 +114,8 @@ public class FabSpeedDial extends LinearLayout implements View.OnClickListener {
     private ColorStateList fabBackgroundTint;
     private ColorStateList miniFabDrawableTint;
     private ColorStateList miniFabBackgroundTint;
+    private ColorStateList miniFabTitleBackgroundTint;
+    private boolean miniFabTitlesEnabled;
     private int miniFabTitleTextColor;
 
     private boolean isAnimating;
@@ -198,6 +200,14 @@ public class FabSpeedDial extends LinearLayout implements View.OnClickListener {
         if (miniFabDrawableTint == null) {
             miniFabDrawableTint = getColorStateList(R.color.mini_fab_drawable_tint);
         }
+
+        miniFabTitleBackgroundTint = typedArray.getColorStateList(R.styleable.FabSpeedDial_miniFabTitleBackgroundTint);
+        if(miniFabTitleBackgroundTint == null){
+            miniFabTitleBackgroundTint = getColorStateList(R.color.mini_fab_title_background_tint);
+        }
+
+        miniFabTitlesEnabled = typedArray.getBoolean(R.styleable.FabSpeedDial_miniFabTitleShow, true);
+
 
         miniFabTitleTextColor = typedArray.getColor(R.styleable.FabSpeedDial_miniFabTitleTextColor,
                 ContextCompat.getColor(getContext(), R.color.title_text_color));
@@ -345,7 +355,8 @@ public class FabSpeedDial extends LinearLayout implements View.OnClickListener {
         ViewCompat.setAlpha(cardView, 0f);
 
         final CharSequence title = menuItem.getTitle();
-        if (!TextUtils.isEmpty(title)) {
+        if (!TextUtils.isEmpty(title) && miniFabTitlesEnabled) {
+            cardView.setBackgroundColor(miniFabTitleBackgroundTint.getDefaultColor());
             titleView.setText(title);
             titleView.setTypeface(null, Typeface.BOLD);
             titleView.setTextColor(miniFabTitleTextColor);

--- a/library/src/main/java/io/github/yavski/fabspeeddial/FabSpeedDial.java
+++ b/library/src/main/java/io/github/yavski/fabspeeddial/FabSpeedDial.java
@@ -206,7 +206,7 @@ public class FabSpeedDial extends LinearLayout implements View.OnClickListener {
             miniFabTitleBackgroundTint = getColorStateList(R.color.mini_fab_title_background_tint);
         }
 
-        miniFabTitlesEnabled = typedArray.getBoolean(R.styleable.FabSpeedDial_miniFabTitleShow, true);
+        miniFabTitlesEnabled = typedArray.getBoolean(R.styleable.FabSpeedDial_miniFabTitlesEnabled, true);
 
 
         miniFabTitleTextColor = typedArray.getColor(R.styleable.FabSpeedDial_miniFabTitleTextColor,
@@ -356,7 +356,7 @@ public class FabSpeedDial extends LinearLayout implements View.OnClickListener {
 
         final CharSequence title = menuItem.getTitle();
         if (!TextUtils.isEmpty(title) && miniFabTitlesEnabled) {
-            cardView.setBackgroundColor(miniFabTitleBackgroundTint.getDefaultColor());
+            cardView.setCardBackgroundColor(miniFabTitleBackgroundTint.getDefaultColor());
             titleView.setText(title);
             titleView.setTypeface(null, Typeface.BOLD);
             titleView.setTextColor(miniFabTitleTextColor);

--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -35,6 +35,9 @@
         <attr name="miniFabDrawableTint" format="color|reference" />
         <attr name="miniFabTitleTextColor" format="color|reference" />
 
+        <attr name="miniFabTitleBackgroundTint" format="color|reference"/>
+        <attr name="miniFabTitlesEnabled" format="boolean"/>
+
     </declare-styleable>
 
 </resources>

--- a/library/src/main/res/values/colors.xml
+++ b/library/src/main/res/values/colors.xml
@@ -20,4 +20,5 @@
     <color name="fab_drawable_tint">@android:color/white</color>
     <color name="mini_fab_drawable_tint">@android:color/black</color>
     <color name="title_text_color">@android:color/black</color>
+    <color name="mini_fab_title_background_tint">@android:color/white</color>
 </resources>


### PR DESCRIPTION
Added optional styling of:

app:miniFabTitleBackgroundTint - controls mini fab title cards colors.

app:miniFabTitlesEnabled  -  gives the option of menuItems to have titles in xml, but hide them when the mini fabs are shown.
