### PR TITLE
Methods to control the state of the FAB and the menu

### DIFF
--- a/library/src/main/java/io/github/yavski/fabspeeddial/FabSpeedDial.java
+++ b/library/src/main/java/io/github/yavski/fabspeeddial/FabSpeedDial.java
@@ -17,11 +17,9 @@
 package io.github.yavski.fabspeeddial;
 
 import android.annotation.TargetApi;
-import android.app.Activity;
 import android.content.Context;
 import android.content.res.ColorStateList;
 import android.content.res.TypedArray;
-import android.graphics.Rect;
 import android.graphics.Typeface;
 import android.graphics.drawable.Drawable;
 import android.os.Build;
@@ -249,25 +247,10 @@ public class FabSpeedDial extends LinearLayout implements View.OnClickListener {
             public void onClick(View v) {
                 if (isAnimating) return;
 
-                if (menuItemsLayout.getChildCount() > 0) {
-                    v.setSelected(false);
-                    removeFabMenuItems();
+                if (isMenuOpen()) {
+                    closeMenu();
                 } else {
-
-                    requestFocus();
-
-                    boolean showMenu = true;
-                    if (menuListener != null) {
-                        newNavigationMenu();
-                        showMenu = menuListener.onPrepareMenu(navigationMenu);
-                    }
-
-                    if (showMenu) {
-                        addMenuItems();
-                        fab.setSelected(true);
-                    } else {
-                        fab.setSelected(false);
-                    }
+                    openMenu();
                 }
             }
         });
@@ -333,6 +316,58 @@ public class FabSpeedDial extends LinearLayout implements View.OnClickListener {
 
     public void setMenuListener(MenuListener menuListener) {
         this.menuListener = menuListener;
+    }
+
+    public boolean isMenuOpen() {
+        return menuItemsLayout.getChildCount() > 0;
+    }
+
+    public void openMenu() {
+        if (!ViewCompat.isAttachedToWindow(this))
+            return;
+        requestFocus();
+
+        boolean showMenu = true;
+        if (menuListener != null) {
+            newNavigationMenu();
+            showMenu = menuListener.onPrepareMenu(navigationMenu);
+        }
+
+        if (showMenu) {
+            addMenuItems();
+            fab.setSelected(true);
+        } else {
+            fab.setSelected(false);
+        }
+    }
+
+    public void closeMenu() {
+        if (!ViewCompat.isAttachedToWindow(this))
+            return;
+
+        if (isMenuOpen()) {
+            fab.setSelected(false);
+            removeFabMenuItems();
+            if (menuListener != null) {
+                menuListener.onMenuClosed();
+            }
+        }
+    }
+
+    public void show() {
+        if (!ViewCompat.isAttachedToWindow(this))
+            return;
+        fab.show();
+    }
+
+    public void hide() {
+        if (!ViewCompat.isAttachedToWindow(this))
+            return;
+
+        if (isMenuOpen()) {
+            closeMenu();
+        }
+        fab.hide();
     }
 
     private void addMenuItems() {
@@ -495,12 +530,11 @@ public class FabSpeedDial extends LinearLayout implements View.OnClickListener {
 
     @Override
     public boolean dispatchKeyEventPreIme(KeyEvent event) {
-        if (menuItemsLayout.getChildCount() > 0
+        if (isMenuOpen()
                 && event.getKeyCode() == KeyEvent.KEYCODE_BACK
                 && event.getAction() == KeyEvent.ACTION_UP
                 && event.getRepeatCount() == 0) {
-            fab.setSelected(false);
-            removeFabMenuItems();
+            closeMenu();
             return true;
         }
 


### PR DESCRIPTION
Added: methods `void show()`, `void hide()`, `void openMenu()`, `void closeMenu()`, `boolean isMenuOpen()`
Fixed: `MenuListener.onMenuClosed` was not called if menu closed with `Back` action
