### PR TITLE
Support for multi-line menu items

### DIFF
--- a/library/src/main/res/layout/fab_menu_item_end.xml
+++ b/library/src/main/res/layout/fab_menu_item_end.xml
@@ -22,12 +22,15 @@
     <android.support.v7.widget.CardView
         android:id="@+id/card_view"
         style="@style/TitleCardView"
-        android:layout_width="match_parent"
+        android:layout_weight="1"
+        android:layout_width="0dp"
         android:layout_height="wrap_content">
 
         <TextView
             android:id="@+id/title_view"
             style="@style/TitleView"
+            android:maxLines="@integer/fab_menu_item_max_lines"
+            android:ellipsize="end"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content" />
 

--- a/library/src/main/res/layout/fab_menu_item_start.xml
+++ b/library/src/main/res/layout/fab_menu_item_start.xml
@@ -30,12 +30,15 @@
     <android.support.v7.widget.CardView
         android:id="@+id/card_view"
         style="@style/TitleCardView"
-        android:layout_width="match_parent"
+        android:layout_weight="1"
+        android:layout_width="0dp"
         android:layout_height="wrap_content">
 
         <TextView
             android:id="@+id/title_view"
             style="@style/TitleView"
+            android:maxLines="@integer/fab_menu_item_max_lines"
+            android:ellipsize="end"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content" />
 

--- a/library/src/main/res/values/values.xml
+++ b/library/src/main/res/values/values.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <integer name="fab_menu_item_max_lines">0x7FFFFFFF</integer>
+</resources>


### PR DESCRIPTION
Fix for menu item appearance if it's too big to fit into the parent view group.
By default the line wrapping will be used, but it could be changed by overriding `@integer/fab_menu_item_max_lines` to configure `maxLines` property of TextView.
