### PR TITLE
Implement custom menu item layouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ The following attribtues are supported:
 | app:miniFabTitlesEnabled | | Convinience for hiding the tilte(s) of the mini FAB(s) |
 | app:touchGuard | | Hide FAB when touching out of its bounds |
 | app:touchGuardDrawable | [android:background](http://developer.android.com/reference/android/view/View.html#setBackground(android.graphics.drawable.Drawable)) | Sets background to the container of FAB 
+| app:menuItemLayoutStart | | Defines a layout for menu items (if start gravity)
+| app: menuItemLayoutEnd | | Defines a layout for menu items (if end gravity)
 
 ### Caveats
 

--- a/library/src/main/java/io/github/yavski/fabspeeddial/FabSpeedDial.java
+++ b/library/src/main/java/io/github/yavski/fabspeeddial/FabSpeedDial.java
@@ -121,6 +121,8 @@ public class FabSpeedDial extends LinearLayout implements View.OnClickListener {
     private int miniFabTitleTextColor;
     private Drawable touchGuardDrawable;
     private boolean useTouchGuard;
+    private int customMenuItemLayoutEnd;
+    private int customMenuItemLayoutStart;
 
     private boolean isAnimating;
 
@@ -219,6 +221,9 @@ public class FabSpeedDial extends LinearLayout implements View.OnClickListener {
         touchGuardDrawable = typedArray.getDrawable(R.styleable.FabSpeedDial_touchGuardDrawable);
 
         useTouchGuard = typedArray.getBoolean(R.styleable.FabSpeedDial_touchGuard, true);
+
+        customMenuItemLayoutEnd = typedArray.getResourceId(R.styleable.FabSpeedDial_menuItemLayoutEnd, 0);
+        customMenuItemLayoutStart = typedArray.getResourceId(R.styleable.FabSpeedDial_menuItemLayoutStart, 0);
     }
 
     @Override
@@ -516,9 +521,9 @@ public class FabSpeedDial extends LinearLayout implements View.OnClickListener {
 
     private int getMenuItemLayoutId() {
         if (isGravityEnd()) {
-            return R.layout.fab_menu_item_end;
+            return (customMenuItemLayoutEnd != 0)? customMenuItemLayoutEnd : R.layout.fab_menu_item_end;
         } else {
-            return R.layout.fab_menu_item_start;
+            return (customMenuItemLayoutStart != 0)? customMenuItemLayoutStart : R.layout.fab_menu_item_start;
         }
     }
 

--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -41,6 +41,8 @@
         <attr name="miniFabTitleBackgroundTint" format="color|reference"/>
         <attr name="miniFabTitlesEnabled" format="boolean"/>
 
+        <attr name="menuItemLayoutEnd" format="reference"/>
+        <attr name="menuItemLayoutStart" format="reference"/>
 
     </declare-styleable>
 

--- a/samples/src/main/res/layout/activity_style_sample.xml
+++ b/samples/src/main/res/layout/activity_style_sample.xml
@@ -57,7 +57,9 @@
             app:fabMenu="@menu/menu_main"
             app:miniFabBackgroundTint="@android:color/white"
             app:miniFabDrawableTint="?attr/colorPrimaryDark"
-            app:miniFabTitleTextColor="?attr/colorPrimaryDark" />
+            app:miniFabTitleTextColor="?attr/colorPrimaryDark"
+            app:menuItemLayoutEnd="@layout/custom_fab_menu_item_end"
+            app:menuItemLayoutStart="@layout/custom_fab_menu_item_start" />
 
     </FrameLayout>
 

--- a/samples/src/main/res/layout/custom_fab_menu_item_end.xml
+++ b/samples/src/main/res/layout/custom_fab_menu_item_end.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright 2016 Yavor Ivanov
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    style="@style/MiniFabLayout"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content">
+
+
+    <android.support.v7.widget.CardView
+        android:id="@+id/card_view"
+        style="@style/TitleCardView"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+
+            <TextView
+                android:id="@+id/title_view"
+                style="@style/TitleView"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textSize="50sp"/>
+
+            <android.support.design.widget.FloatingActionButton
+                android:id="@+id/mini_fab"
+                style="@style/MiniFab"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="20dp"
+                android:layout_marginLeft="20dp" />
+
+        </LinearLayout>
+    </android.support.v7.widget.CardView>
+
+</LinearLayout>

--- a/samples/src/main/res/layout/custom_fab_menu_item_start.xml
+++ b/samples/src/main/res/layout/custom_fab_menu_item_start.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright 2016 Yavor Ivanov
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    style="@style/MiniFabLayout"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content">
+
+    <android.support.v7.widget.CardView
+        android:id="@+id/card_view"
+        style="@style/TitleCardView"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+
+            <android.support.design.widget.FloatingActionButton
+                android:id="@+id/mini_fab"
+                style="@style/MiniFab"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="10dp"
+                android:layout_marginStart="10dp" />
+
+            <TextView
+                android:id="@+id/title_view"
+                style="@style/TitleView"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textSize="50sp"/>
+
+        </LinearLayout>
+    </android.support.v7.widget.CardView>
+
+</LinearLayout>


### PR DESCRIPTION
I wanted to style the menu items a little more than is currently available, so wrote a patch for it.

Adds `menuItemLayoutStart` and `menuItemLayoutEnd` to FabSpeedDial attributes.
FAB will use them if defined, or default to the existing fab_menu_item_[end|start] layouts.

Includes a sample custom layout and uses it in the Style sample activity.
(would it be better to add a new activity?)

Adds both new attributes to the README.

This change is intended to add functionality but be fully backwards-compatible.
