### PR TITLE
Adding support for individual miniFab drawable tinting

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,6 @@ Similarly tо [NavigationView] (http://developer.android.com/reference/android/s
 
 ### Gettting started
 
-##### Add the dependency to gradle.build
-```
-dependencies {
-    compile 'io.github.yavski:fab-speed-dial:1.0.6'
-}
-```
-
 ##### Define a menu resource
 ```
 <menu xmlns:android="http://schemas.android.com/apk/res/android"

--- a/library/src/main/java/io/github/yavski/fabspeeddial/FabSpeedDial.java
+++ b/library/src/main/java/io/github/yavski/fabspeeddial/FabSpeedDial.java
@@ -119,6 +119,7 @@ public class FabSpeedDial extends LinearLayout implements View.OnClickListener {
     private ColorStateList miniFabDrawableTint;
     private ColorStateList miniFabBackgroundTint;
     private int[] miniFabBackgroundTintArray;
+    private int[] miniFabDrawableTintArray;
     private ColorStateList miniFabTitleBackgroundTint;
     private boolean miniFabTitlesEnabled;
     private int miniFabTitleTextColor;
@@ -220,6 +221,19 @@ public class FabSpeedDial extends LinearLayout implements View.OnClickListener {
         miniFabDrawableTint = typedArray.getColorStateList(R.styleable.FabSpeedDial_miniFabDrawableTint);
         if (miniFabDrawableTint == null) {
             miniFabDrawableTint = getColorStateList(R.color.mini_fab_drawable_tint);
+        }
+
+        if (typedArray.hasValue(R.styleable.FabSpeedDial_miniFabDrawableTintList)) {
+            int miniFabDrawableTintListId =
+                    typedArray.getResourceId(R.styleable.FabSpeedDial_miniFabDrawableTintList, 0);
+            TypedArray miniFabDrawableTintRes =
+                    getResources().obtainTypedArray(miniFabDrawableTintListId);
+            miniFabDrawableTintArray = new int[miniFabDrawableTintRes.length()];
+            for (int i = 0; i < miniFabDrawableTintRes.length(); i++) {
+                miniFabDrawableTintArray[i] = miniFabDrawableTintRes.getResourceId(i, 0);
+            }
+            miniFabDrawableTintRes.recycle();
+
         }
 
         miniFabTitleBackgroundTint = typedArray.getColorStateList(R.styleable.FabSpeedDial_miniFabTitleBackgroundTint);
@@ -496,6 +510,11 @@ public class FabSpeedDial extends LinearLayout implements View.OnClickListener {
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
             miniFab.setImageTintList(miniFabDrawableTint);
+        }
+
+        if (miniFabDrawableTintArray != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            miniFab.setImageTintList(ContextCompat.getColorStateList(getContext(),
+                    miniFabDrawableTintArray[menuItem.getOrder()]));
         }
 
         return fabMenuItem;

--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -34,6 +34,7 @@
         <attr name="miniFabBackgroundTint" format="color|reference" />
         <attr name="miniFabBackgroundTintList" format="reference" />
         <attr name="miniFabDrawableTint" format="color|reference" />
+        <attr name="miniFabDrawableTintList" format="reference" />
         <attr name="miniFabTitleTextColor" format="color|reference" />
         <attr name="miniFabTitleTextColorList" format="reference" />
 


### PR DESCRIPTION
Same set up as customizing the miniFab background.
Set up an array resource of colors and add `app:miniFabDrawableTintList` to the FabSpeedDial XML

Note: This will only work on api 21+(Lollipop or later)

Example:
```
<integer-array name="fab_menu_item_drawable_colors" >
        <item>@color/holo_green_light</item>
        <item>@color/holo_orange_dark</item>
        <item>@color/holo_purple</item>
</integer-array>
```


```
<io.github.yavski.fabspeeddial.FabSpeedDial
    ...
    app:miniFabDrawableTintList="@array/fab_menu_item_drawable_colors" />
```
